### PR TITLE
Add missing API group extensions

### DIFF
--- a/charts/jenkins-master/templates/k8s-mgmt-jenkins-agent-deploy-ns-rbac.yaml
+++ b/charts/jenkins-master/templates/k8s-mgmt-jenkins-agent-deploy-ns-rbac.yaml
@@ -19,7 +19,7 @@ rules:
   - apiGroups: ["", "apps"]
     resources: ["configmaps", "services", "deployments", "replicasets", "pods", "statefulsets", "secrets", "persistentvolumeclaims"]
     verbs: ["*"]
-  - apiGroups: ["networking.k8s.io"]
+  - apiGroups: ["networking.k8s.io", "extensions"]
     resources: ["ingresses"]
     verbs: ["*"]
 


### PR DESCRIPTION
This API group is missing to have all needed rights to deploy from one namespace to an other namespace